### PR TITLE
Mongo driver: fixes of a few explicit blocking syncs

### DIFF
--- a/src/main/scala/org/ada/server/akka/AkkaStreamUtil.scala
+++ b/src/main/scala/org/ada/server/akka/AkkaStreamUtil.scala
@@ -162,6 +162,10 @@ object AkkaStreamUtil {
       (header, contentSource)
     )
   }
+
+  // TODO: since Akka 2.5.x provided by Source.fromFutureSource... remove once the lib is upgraded
+  def fromFutureSource[out, mat](futureSource: Future[Source[out, mat]]): Source[out, NotUsed] =
+    Source.fromGraph(Source.fromFuture(futureSource).flatMapConcat(identity))
 }
 
 object AkkaTest extends App {

--- a/src/main/scala/org/ada/server/dataaccess/ignite/AbstractCacheAsyncCrudRepoProvider.scala
+++ b/src/main/scala/org/ada/server/dataaccess/ignite/AbstractCacheAsyncCrudRepoProvider.scala
@@ -1,6 +1,5 @@
 package org.ada.server.dataaccess.ignite
 
-
 import java.io.Serializable
 import java.util
 import javax.cache.Cache.Entry

--- a/src/main/scala/org/ada/server/dataaccess/ignite/BinaryCacheFactory.scala
+++ b/src/main/scala/org/ada/server/dataaccess/ignite/BinaryCacheFactory.scala
@@ -26,7 +26,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class BinaryCacheFactory @Inject()(ignite: Ignite) extends Serializable {
 
-  private val logger = Logger
   private val ftf = FieldTypeHelper.fieldTypeFactory()
 
   def apply[ID](

--- a/src/main/scala/org/ada/server/dataaccess/mongo/MongoAsyncRepo.scala
+++ b/src/main/scala/org/ada/server/dataaccess/mongo/MongoAsyncRepo.scala
@@ -15,8 +15,6 @@ import org.ada.server.akka.AkkaStreamUtil
 import reactivemongo.play.json.collection.JSONBatchCommands
 import JSONBatchCommands.AggregationFramework.GroupFunction
 import akka.NotUsed
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 protected class MongoAsyncRepo[E: Format, ID: Format](
     collectionName : String)(
@@ -196,15 +194,8 @@ class MongoAsyncStreamRepo[E: Format, ID: Format](
 
   @Inject implicit var materializer: Materializer = _
 
-  override lazy val stream: Source[E, Future[State]] = {
-    val futureSource = akkaCursor.map(_.documentSource())
-    Await.result(futureSource, 1 minute)
-  }
-
-//  override lazy val oldStream: Enumerator[E] = {
-//    val enumerator = Enumerator.flatten(akkaCursor.map(_.enumerate()))
-//    Concurrent.broadcast(enumerator)._1
-//  }
+  override lazy val stream: Source[E, NotUsed] =
+    AkkaStreamUtil.fromFutureSource(akkaCursor.map(_.documentSource()))
 
   import reactivemongo.akkastream.cursorProducer
 


### PR DESCRIPTION
- Removing Await.result from MongoAsyncStreamRepo by 'flattening' a future source/stream
- Switching ReactiveMongo.db from a sync instance to an async (future) call

